### PR TITLE
Should add PBS resource requirement directives

### DIFF
--- a/main
+++ b/main
@@ -1,4 +1,5 @@
 #!/bin/bash
+#PBS -l nodes=1:ppn=1,vmem=8gb,walltime=2:00:00
 
 # dependencies:
 # python2.7 with numpy and nibabel


### PR DESCRIPTION
This app currently doesn't set walltime / memory requests. It should add something like
> #PBS -l nodes=1:ppn=1,vmem=8gb,walltime=2:00:00